### PR TITLE
Add BetterBags category function

### DIFF
--- a/Equipment.lua
+++ b/Equipment.lua
@@ -3017,6 +3017,24 @@ if LibStub and LibStub:GetLibrary("AceAddon-3.0", true) then
 	end
 end
 
+-- BetterBags
+if LibStub and LibStub:GetLibrary("AceAddon-3.0", true) then
+	local BetterBags = LibStub("AceAddon-3.0"):GetAddon("BetterBags", true)
+
+	if BetterBags then
+		local categories = BetterBags:GetModule('Categories')
+		categories:RegisterCategoryFunction("BtWLoadouts", function(data)
+			local location = PackLocation(data.bagid, data.slotid)
+			local sets = {}
+			local set = GetEnabledSetsForLocation(location, sets)[1]
+			if set then
+				return format(L["Set: %s"], set.name)
+			end
+			return nil
+		end)
+	end
+end
+
 -- LibItemSearch, used by Bagnon to display borders around items within equipment sets
 if LibStub and LibStub:GetLibrary("LibItemSearch-1.2", true) then
 	local Lib = LibStub("LibItemSearch-1.2")

--- a/Equipment.lua
+++ b/Equipment.lua
@@ -3022,16 +3022,30 @@ if LibStub and LibStub:GetLibrary("AceAddon-3.0", true) then
 	local BetterBags = LibStub("AceAddon-3.0"):GetAddon("BetterBags", true)
 
 	if BetterBags then
+		local setCategories = {}
 		local categories = BetterBags:GetModule('Categories')
 		categories:RegisterCategoryFunction("BtWLoadouts", function(data)
 			local location = PackLocation(data.bagid, data.slotid)
 			local sets = {}
 			local set = GetEnabledSetsForLocation(location, sets)[1]
 			if set then
-				return format(L["Set: %s"], set.name)
+				local category = format(L["Set: %s"], set.name)
+				setCategories[category] = true
+				return category
 			end
 			return nil
 		end)
+
+		-- Delete custom categories created by BtWLoadouts on haracter logout
+		-- This ensures only categories for sets of the current character are displayed
+		local frame = CreateFrame("Frame")
+		frame:SetScript("OnEvent", function ()
+			for category in pairs(setCategories) do
+				categories:DeleteCategory(category)
+			end
+		end)
+		frame:RegisterEvent("PLAYER_LOGOUT")
+		frame:Hide()
 	end
 end
 

--- a/Equipment.lua
+++ b/Equipment.lua
@@ -3036,8 +3036,8 @@ if LibStub and LibStub:GetLibrary("AceAddon-3.0", true) then
 			return nil
 		end)
 
-		-- Delete custom categories created by BtWLoadouts on haracter logout
-		-- This ensures only categories for sets of the current character are displayed
+		-- Delete custom categories created by BtWLoadouts on character logout
+		-- This ensures only categories for sets enabled for the current character are displayed
 		local frame = CreateFrame("Frame")
 		frame:SetScript("OnEvent", function ()
 			for category in pairs(setCategories) do


### PR DESCRIPTION
Register a category function on the [AdiBags successor addon BetterBags](https://github.com/AdiAddons/AdiBags/issues/997).

The category function will create a custom category for each item set and correctly alocate the items on the right category.

Screenshots:
![image](https://github.com/Breeni/BtWLoadouts/assets/7741292/991993df-8e64-42f3-82de-5a52b52d57a8)
![image](https://github.com/Breeni/BtWLoadouts/assets/7741292/6532a21a-2adc-4722-9f5d-ef6acf93eb77)
![image](https://github.com/Breeni/BtWLoadouts/assets/7741292/3cf586b6-4ee2-4672-968c-ca958fb4e256)
