### PR TITLE
Fix Lua error when visualizing equipments from other characters

### DIFF
--- a/Equipment.lua
+++ b/Equipment.lua
@@ -1989,11 +1989,7 @@ function BtWLoadoutsEquipmentMixin:Update()
 		self.Name:SetEnabled(set.managerID == nil or set.character == playerCharacter);
 
 		local model = self.Model;
-		if not characterInfo or character == playerCharacter then
-			model:SetUnit("player");
-		else
-			model:SetCustomRace(characterInfo.race, characterInfo.sex);
-		end
+		model:SetUnit("player");
 		model:Undress();
 
 		for _,item in pairs(self.Slots) do


### PR DESCRIPTION
The function "SetCustomRace" was removed in 10.1.5 causing the following Lua error:
```
BtWLoadouts/Equipment.lua:1995: attempt to call method 'SetCustomRace' (a nil value)
[string "@BtWLoadouts/Equipment.lua"]:1995: in function `Update'
[string "@BtWLoadouts/BtWLoadouts.lua"]:1704: in function `Update'
[string "*BtWLoadouts.xml:413_OnClick"]:3: in function <[string "*BtWLoadouts.xml:413_OnClick"]:1>
```

I tried a couple things with "SetDisplayInfo" but that resulted in a white model with no texture, the race and apparence was correct but ultimately the gear wasn't correctly displayed due to the lack of texture.

It seems even addons like [Narcissus](https://github.com/search?q=repo%3APeterodox%2FNarcissus%20SetCustomRace&type=code) removed it's options to set custom race and gender.

For now I think this is a good quick fix to get rid of the Lua error and make the sets visible again, displaying it on the current logged in character.

Without the fix:
![image](https://github.com/Breeni/BtWLoadouts/assets/7741292/6489cacb-c1e1-41e0-aa35-8e831912c0b5)

With the fix:
![image](https://github.com/Breeni/BtWLoadouts/assets/7741292/78778045-54ab-479a-87ed-3315aea5c92d)
